### PR TITLE
chore: add gitignore file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,14 +3,23 @@ node_modules
 
 # Build outputs
 dist/
-build/
+out/
+
+# VS Code extension packaging
+*.vsix
+
+# VS Code test runner
+.vscode-test/
+
+# logs
+npm-debug.log
+pnpm-debug.log*
+*.log
 
 # Environment variables
 .env 
 .env*
 
-# logs
-npm-debug.log
-
 # Editor 
 .vscode/
+.DS_Store


### PR DESCRIPTION
Adds a .gitignore file to prevent committing unnecessary files like node_modules and env files.

### Related Issue
Fixes #13 
